### PR TITLE
Implements support for adding a cache to this middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,11 +199,9 @@ A more useful possibility is to give `[CALL_API].bailout` a function. At runtime
 
 Often it is useful to be able to cache the API call being made to the server.
 
-You can tell `redux-api-middleware` to use a cache through `[CALL_API].cache`. The value should point to a function that will be passed the endpoint as the first argument and the resulting JSON data as the second argument.
+You can tell `redux-api-middleware` to use a cache through `[CALL_API].cache`. The value should point to an object implementing a cache API (see [`[CALL_API].cache`](#call_apicache)) with these three functions: `has` `get` and `set`.
 
-The second argument will only be passed when an API call has been made and there is data to store in the cache. If the function is called with only the endpoint it should return the cached data, if present.
-
-**NOTE** You will only be able to use a `[CALL_API].cache` function for APIs returning JSON data.
+**NOTE** You will only be able to use a `[CALL_API].cache` API for endpoints returning JSON data.
 
 An example cache implementation could look like this:
 
@@ -211,13 +209,15 @@ An example cache implementation could look like this:
 {
   [CALL_API]: {
     ...
-    cache: (endpoint, dataToCache) => {
-      if (dataToCache) {
-        // Add data to cache
-        someCacheImplementation.put(endpoint, dataToCache);
-      } else {
-        // Return possibly cached data
-        return someCacheImplementation.has(endpoint) ? someCacheImplementation.get(endpoint) : undefined;
+    cache: {
+      has: (endpoint) => someCacheImplementation.has(endpoint),
+      async get(endpoint) {
+       // Returns cached data for endpoint
+       return someCacheImplementation.get(endpoint);
+      },
+      set(endpoint, jsonToCache) {
+       // Adds data to cache for key endpoint
+       someCacheImplementation.set(endpoint, jsonToCache);
       }
     }
     ...
@@ -623,7 +623,16 @@ The optional `[CALL_API].bailout` property MUST be a boolean or a function.
 
 #### `[CALL_API].cache`
 
-The optional `[CALL_API].cache` property MUST be a function.
+The optional `[CALL_API].cache` property MUST be a plain JavaSCript object implementing the functions `has`, `get` and `set`.
+
+##### `has(endpoint)`
+Takes an `endpoint` as its only argument. Should return `true` if the endpoint is in the cache and valid. Otherwise `false` should be returned.
+
+##### `get(endpoint)`
+Takes an `endpoint` as its only argument. Should return the cached result for the given endpoint.
+
+##### `set(endpoint, jsonToCache)`
+Takes an `endpoint` and the `jsonToCache` (the result of calling the endpoint) as its argument. The implementation should store the `jsonToCache` in the cache.
 
 #### `[CALL_API].types`
 

--- a/README.md
+++ b/README.md
@@ -623,7 +623,7 @@ The optional `[CALL_API].bailout` property MUST be a boolean or a function.
 
 #### `[CALL_API].cache`
 
-The optional `[CALL_API].cache` property MUST be a plain JavaSCript object implementing the functions `has`, `get` and `set`.
+The optional `[CALL_API].cache` property MUST be a plain JavaScript object implementing the functions `has`, `get` and `set`.
 
 ##### `has(endpoint)`
 Takes an `endpoint` as its only argument. Should return `true` if the endpoint is in the cache and valid. Otherwise `false` should be returned.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ redux-api-middleware
 3. [Usage](#usage)
   - [Defining the API call](#defining-the-api-call)
   - [Bailing out](#bailing-out)
+  - [Caching](#caching)
   - [Lifecycle](#lifecycle)
   - [Customizing the dispatched FSAs](#customizing-the-dispatched-fsas)
 4. [Reference](#reference)
@@ -193,6 +194,36 @@ In some cases, the data you would like to fetch from the server may already be c
 You can tell `redux-api-middleware` to not make the API call through `[CALL_API].bailout`. If the value is `true`, the RSAA will die here, and no FSA will be passed on to the next middleware.
 
 A more useful possibility is to give `[CALL_API].bailout` a function. At runtime, it will be passed the state of your Redux store as its only argument, if the return value of the function is `true`, the API call will not be made.
+
+### Caching
+
+Often it is useful to be able to cache the API call being made to the server.
+
+You can tell `redux-api-middleware` to use a cache through `[CALL_API].cache`. The value should point to a function that will be passed the endpoint as the first argument and the resulting JSON data as the second argument.
+
+The second argument will only be passed when an API call has been made and there is data to store in the cache. If the function is called with only the endpoint it should return the cached data, if present.
+
+**NOTE** You will only be able to use a `[CALL_API].cache` function for APIs returning JSON data.
+
+An example cache implementation could look like this:
+
+```js
+{
+  [CALL_API]: {
+    ...
+    cache: (endpoint, dataToCache) => {
+      if (dataToCache) {
+        // Add data to cache
+        someCacheImplementation.put(endpoint, dataToCache);
+      } else {
+        // Return possibly cached data
+        return someCacheImplementation.has(endpoint) ? someCacheImplementation.get(endpoint) : undefined;
+      }
+    }
+    ...
+  }
+}
+```
 
 ### Lifecycle
 
@@ -555,10 +586,11 @@ The `[CALL_API]` property MAY
 - have an `options` property,
 - have a `credentials` property,
 - have a `bailout` property.
+- have a `cache` property.
 
 The `[CALL_API]` property MUST NOT
 
-- include properties other than `endpoint`, `method`, `types`, `body`, `headers`, `options`, `credentials`, and `bailout`.
+- include properties other than `endpoint`, `method`, `types`, `body`, `headers`, `options`, `credentials`, `bailout` and `cache`.
 
 #### `[CALL_API].endpoint`
 
@@ -588,6 +620,10 @@ The optional `[CALL_API].credentials` property MUST be one of the strings `omit`
 #### `[CALL_API].bailout`
 
 The optional `[CALL_API].bailout` property MUST be a boolean or a function.
+
+#### `[CALL_API].cache`
+
+The optional `[CALL_API].cache` property MUST be a function.
 
 #### `[CALL_API].types`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aftonbladet/redux-api-middleware",
-  "version": "1.0.2-3",
+  "version": "1.1.0",
   "description": "Redux middleware for calling an API.",
   "main": "lib/index.js",
   "scripts": {
@@ -11,8 +11,8 @@
     "prepublish": "npm run lint && npm test && npm run clean && npm run build",
     "test": "babel-node test/index.js | tap-spec"
   },
-  "repository": "agraboso/redux-api-middleware",
-  "homepage": "https://github.com/agraboso/redux-api-middleware",
+  "repository": "Aftonbladet/redux-api-middleware",
+  "homepage": "https://github.com/Aftonbladet/redux-api-middleware",
   "keywords": [
     "redux",
     "api",

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,10 +1,9 @@
 import fetch from 'isomorphic-fetch';
-import isPlainObject from 'lodash.isplainobject';
 
 import CALL_API from './CALL_API';
 import { isRSAA, validateRSAA } from './validation';
-import { InvalidRSAA, RequestError, ApiError } from './errors' ;
-import { getJSON, normalizeTypeDescriptors, actionWith } from './util';
+import { InvalidRSAA, RequestError } from './errors' ;
+import { normalizeTypeDescriptors, actionWith, fakeJsonResponse } from './util';
 
 /**
  * A Redux middleware that processes RSAA actions.
@@ -40,7 +39,7 @@ function apiMiddleware({ getState }) {
     // Parse the validated RSAA action
     const callAPI = action[CALL_API];
     var { endpoint, headers, options = {} } = callAPI;
-    const { method, body, credentials, bailout, types } = callAPI;
+    const { method, body, credentials, bailout, types, cache } = callAPI;
     const [requestType, successType, failureType] = normalizeTypeDescriptors(types);
 
     // Should we bail out?
@@ -69,6 +68,28 @@ function apiMiddleware({ getState }) {
           {
             ...requestType,
             payload: new RequestError('[CALL_API].endpoint function failed'),
+            error: true
+          },
+          [action, getState()]
+        ));
+      }
+    }
+
+    // Is it cached?
+    if (typeof cache === 'function') {
+      try {
+        const cachedJson = await cache(endpoint);
+        if (cachedJson) {
+          return next(await actionWith(
+              successType,
+              [action, getState(), fakeJsonResponse(cachedJson)]
+          ));
+        }
+      } catch (e) {
+        return next(await actionWith(
+          {
+            ...requestType,
+            payload: new RequestError(`[CALL_API].cache function failed: ${e.message}`),
             error: true
           },
           [action, getState()]
@@ -134,10 +155,14 @@ function apiMiddleware({ getState }) {
 
     // Process the server response
     if (res.ok) {
-      return next(await actionWith(
-        successType,
-        [action, getState(), res]
-      ));
+      const action = await actionWith(
+          successType,
+          [action, getState(), res]
+      );
+      if (typeof cache === 'function') {
+        cache(endpoint, action.payload);
+      }
+      return next(action);
     } else {
       return next(await actionWith(
         {

--- a/src/util.js
+++ b/src/util.js
@@ -19,6 +19,32 @@ async function getJSON(res) {
   }
 }
 
+function _fakeHeader(header = '') {
+  if (header.toLowerCase() === 'content-type') {
+    return 'application/json';
+  } else {
+    return 'faked header - cache is only supported for json responses';
+  }
+}
+
+/**
+ * Creates a faked fetch response that will return the given JSON
+ * when the `json` method is called. This is used when a JSON cache
+ * is used.
+ *
+ * @param {object} json the json to return by the faked fetch response
+ * @returns {{headers: {get: _fakeHeader}, status: number, statusText: string, json: json}}
+ */
+function fakeJsonResponse(json) {
+  return {
+    headers: { get: _fakeHeader },
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: function () { return json; }
+  };
+}
+
 /**
  * Blow up string or symbol types into full-fledged type descriptors,
  *   and add defaults
@@ -93,4 +119,4 @@ async function actionWith(descriptor, args) {
   return descriptor;
 }
 
-export { getJSON, normalizeTypeDescriptors, actionWith };
+export { getJSON, fakeJsonResponse, normalizeTypeDescriptors, actionWith };

--- a/src/validation.js
+++ b/src/validation.js
@@ -103,7 +103,7 @@ function validateRSAA(action) {
     }
   }
 
-  const { endpoint, method, headers, options, credentials, types, bailout } = callAPI;
+  const { endpoint, method, headers, options, credentials, types, bailout, cache } = callAPI;
   if (typeof endpoint === 'undefined') {
     validationErrors.push('[CALL_API] must have an endpoint property');
   } else if (typeof endpoint !== 'string' && typeof endpoint !== 'function') {

--- a/src/validation.js
+++ b/src/validation.js
@@ -81,7 +81,7 @@ function validateRSAA(action) {
     'same-origin',
     'include'
   ];
-  const validCacheFunctions = [
+  const requiredCacheFunctions = [
     'has',
     'get',
     'set'
@@ -156,13 +156,9 @@ function validateRSAA(action) {
     }
   }
 
-  if (typeof cache !== 'undefined') {
-    if (!isPlainObject(cache)) {
-      validationErrors.push('[CALL_API].cache property must be undefined or a plain JavaScript object');
-    } else if (Object.keys(cache).filter((k) => validCacheFunctions.indexOf(k) === -1).length > 0) {
-      validationErrors.push(`Invalid [CALL_API].cache functions: ${Object.keys(cache)}`);
-    } else if (typeof cache.has !== 'function' && typeof cache.get !== 'function' && typeof cache.set !== 'function') {
-      validationErrors.push(`[CALL_API].cache property must be an object implementing the functions: ${validCacheFunctions}`);
+  if (cache != null) {
+    if (!requiredCacheFunctions.every((f) => typeof cache[f] === 'function')) {
+      validationErrors.push(`[CALL_API].cache property must be undefined or an object implementing the functions: ${requiredCacheFunctions}`);
     }
   }
 

--- a/src/validation.js
+++ b/src/validation.js
@@ -81,6 +81,11 @@ function validateRSAA(action) {
     'same-origin',
     'include'
   ];
+  const validCacheFunctions = [
+    'has',
+    'get',
+    'set'
+  ];
 
   if (!isRSAA(action)) {
     validationErrors.push('RSAAs must be plain JavaScript objects with a [CALL_API] property');
@@ -151,8 +156,14 @@ function validateRSAA(action) {
     }
   }
 
-  if (typeof cache !== 'undefined' && typeof cache !== 'function') {
-    validationErrors.push('[CALL_API].cache property must be undefined or a function');
+  if (typeof cache !== 'undefined') {
+    if (!isPlainObject(cache)) {
+      validationErrors.push('[CALL_API].cache property must be undefined or a plain JavaScript object');
+    } else if (Object.keys(cache).filter((k) => validCacheFunctions.indexOf(k) === -1).length > 0) {
+      validationErrors.push(`Invalid [CALL_API].cache functions: ${Object.keys(cache)}`);
+    } else if (typeof cache.has !== 'function' && typeof cache.get !== 'function' && typeof cache.set !== 'function') {
+      validationErrors.push(`[CALL_API].cache property must be an object implementing the functions: ${validCacheFunctions}`);
+    }
   }
 
   return validationErrors;

--- a/src/validation.js
+++ b/src/validation.js
@@ -26,7 +26,7 @@ function isValidTypeDescriptor(obj) {
     'type',
     'payload',
     'meta'
-  ]
+  ];
 
   if (!isPlainObject(obj)) {
     return false;
@@ -64,7 +64,8 @@ function validateRSAA(action) {
     'headers',
     'credentials',
     'bailout',
-    'types'
+    'types',
+    'cache'
   ];
   const validMethods = [
     'GET',
@@ -79,7 +80,7 @@ function validateRSAA(action) {
     'omit',
     'same-origin',
     'include'
-  ]
+  ];
 
   if (!isRSAA(action)) {
     validationErrors.push('RSAAs must be plain JavaScript objects with a [CALL_API] property');
@@ -148,6 +149,10 @@ function validateRSAA(action) {
     if (typeof failureType !== 'string' && typeof failureType !== 'symbol' && !isValidTypeDescriptor(failureType)) {
       validationErrors.push('Invalid failure type');
     }
+  }
+
+  if (typeof cache !== 'undefined' && typeof cache !== 'function') {
+    validationErrors.push('[CALL_API].cache property must be undefined or a function');
   }
 
   return validationErrors;

--- a/test/index.js
+++ b/test/index.js
@@ -532,12 +532,12 @@ test('validateRSAA/isValidRSAA must identify conformant RSAAs', (t) => {
     }
   };
   t.ok(
-      validateRSAA(action27).includes('[CALL_API].cache property must be undefined or a plain JavaScript object'),
-      '[CALL_API].cache property must be undefined or a plain JavaScript object (validateRSAA)'
+      validateRSAA(action27).includes('[CALL_API].cache property must be undefined or an object implementing the functions: has,get,set'),
+      '[CALL_API].cache property must be undefined or an object implementing the functions: has,get,set (validateRSAA)'
   );
   t.notOk(
       isValidRSAA(action27),
-      '[CALL_API].cache property must be undefined or a plain JavaScript object (isValidRSAA)'
+      '[CALL_API].cache property must be undefined or an object implementing the functions: has,get,set (isValidRSAA)'
   );
 
   const action28 = {
@@ -546,39 +546,22 @@ test('validateRSAA/isValidRSAA must identify conformant RSAAs', (t) => {
       method: 'GET',
       types: ['REQUEST', 'SUCCESS', 'FAILURE'],
       cache: {
-        what: () => {},
+        has: '',
+        set: '',
+        get: ''
       }
     }
   };
   t.ok(
-    validateRSAA(action28).includes(`Invalid [CALL_API].cache functions: ${Object.keys(action28[CALL_API].cache)}`),
-    `Invalid [CALL_API].cache functions: ${Object.keys(action28[CALL_API].cache)} (validateRSAA)`
+    validateRSAA(action28).includes('[CALL_API].cache property must be undefined or an object implementing the functions: has,get,set'),
+    '[CALL_API].cache property must be undefined or an object implementing the functions: has,get,set (validateRSAA)'
   );
   t.notOk(
     isValidRSAA(action28),
-    `Invalid [CALL_API].cache functions: ${Object.keys(action28[CALL_API].cache)} (isValidaRSAA)`
+    '[CALL_API].cache property must be undefined or an object implementing the functions: has,get,set (isValidRSAA)'
   );
 
   const action29 = {
-    [CALL_API]: {
-      endpoint: '',
-      method: 'GET',
-      types: ['REQUEST', 'SUCCESS', 'FAILURE'],
-      cache: {
-        set: ''
-      }
-    }
-  };
-  t.ok(
-    validateRSAA(action29).includes('[CALL_API].cache property must be an object implementing the functions: has,get,set'),
-    '[CALL_API].cache property must be an object implementing the functions: has,get,set (validateRSAA)'
-  );
-  t.notOk(
-    isValidRSAA(action29),
-    '[CALL_API].cache property must be an object implementing the functions: has,get,set (isValidRSAA)'
-  );
-
-  const action30 = {
     [CALL_API]: {
       endpoint: '',
       method: 'GET',
@@ -591,12 +574,12 @@ test('validateRSAA/isValidRSAA must identify conformant RSAAs', (t) => {
     }
   };
   t.equal(
-      validateRSAA(action30).length,
+      validateRSAA(action29).length,
       0,
       '[CALL_API].cache may be an object implementing the functions: has,get,set (validateRSAA)'
   );
   t.ok(
-      isValidRSAA(action30),
+      isValidRSAA(action29),
       '[CALL_API].cache may be an object implementing the functions: has,get,set (isValidRSAA)'
   );
 


### PR DESCRIPTION
If this is something to move forward with I'll add tests and documentation.

Typical usage:
```js
{
    [CALL_API]: {
        endpoint: `${apiUrl}${path}/latest/${metaValue}?size=${size}&from=${from}`,
        types: [
            types.REQUEST_LATEST_NEWS,
            types.RECEIVE_LATEST_NEWS,
            types.RECEIVE_LATEST_NEWS_ERROR,
        ],
        cache: async (endpoint, dataToCache) => {
            if (dataToCache) {
                console.log('Adding data to cache', endpoint);
                return await latestNewsCache.get(endpoint, () => dataToCache);
            } else {
                console.log('Looking in cache for', endpoint);
                return latestNewsCache.has(endpoint) ? await latestNewsCache.get(endpoint) : undefined;
            }
        }
}
```

Ping @PAkerstrand @dentrado.